### PR TITLE
chore(test): add assertj-core dependency to timeless-api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,13 +45,18 @@ Suggestions for improvements are also logged as [GitHub Issues](https://github.c
 
 1. Fork the repository and clone it locally.
 2. Create a branch for your edit: `git checkout -b my-new-feature`.
-3. Make your changes and commit: `git commit -m 'feat: Adds new feature'`.
+3. Make your changes and commit: `git commit -m 'feat: add some feature'`.
 4. Push to the original branch: `git push origin my-new-feature`.
 5. Create a Pull Request.
 
 ### Before Submitting a PR
 
 To ensure your code follows the project's standards and passes the CI pipeline, please run the following commands before submitting your Pull Request.
+
+#### Tests
+
+- We must use assertj library (we use it already in the project) for assertions.
+- The test naming must be `should_expectedBehavior_when_stateUnderTest` example: `should_throwException_when_ageLessThan18`.
 
 #### Backend (Java/Quarkus)
 

--- a/timeless-api/pom.xml
+++ b/timeless-api/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>dev.matheuscruz</groupId>
     <artifactId>timeless-api</artifactId>
@@ -19,6 +20,7 @@
         <quarkus-quinoa.version>2.5.4</quarkus-quinoa.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <quarkus-langchain4j-openai.version>1.0.0.CR1</quarkus-langchain4j-openai.version>
+        <assertj.version>3.27.6</assertj.version>
     </properties>
 
     <dependencyManagement>
@@ -67,16 +69,6 @@
             <version>${quarkus-quinoa.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkiverse.langchain4j</groupId>
             <artifactId>quarkus-langchain4j-openai</artifactId>
             <version>${quarkus-langchain4j-openai.version}</version>
@@ -113,6 +105,23 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -164,7 +173,8 @@
                 </executions>
                 <configuration>
                     <systemPropertyVariables>
-                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner
+                        <native.image.path>
+                            ${project.build.directory}/${project.build.finalName}-runner
                         </native.image.path>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>


### PR DESCRIPTION
## Pull request overview

This PR adds the assertj-core testing library as a dependency to the timeless-api module and establishes test guidelines in the contributing documentation.

- Adds assertj-core 3.27.6 as a test dependency with proper Maven property configuration
- Reorganizes test dependencies in pom.xml to group them together at the end
- Updates CONTRIBUTING.md with new test guidelines including assertj usage requirement and naming conventions

### Reviewed changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated 1 comment.

| File | Description |
| ---- | ----------- |
| timeless-api/pom.xml | Adds assertj-core dependency, reorganizes test dependencies, and includes XML formatting improvements |
| CONTRIBUTING.md | Updates test guidelines to mandate assertj usage and defines test naming conventions |





---

💡 <a href="/mcruzdev/timeless/new/main/.github/instructions?filename=*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.