### PR TITLE
ci: otimization detect changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,14 +6,12 @@ on:
     paths:
       - 'timeless-api/**'
       - 'whatsapp/**'
-    paths-ignore:
       - 'infrastructure/**'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'timeless-api/**'
       - 'whatsapp/**'
-    paths-ignore:
       - 'infrastructure/**'
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,16 @@ name: Timeless CI - Build & Publish
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'timeless-api/**'
+      - 'whatsapp/**'
     paths-ignore:
       - 'infrastructure/**'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'timeless-api/**'
+      - 'whatsapp/**'
     paths-ignore:
       - 'infrastructure/**'
 
@@ -21,8 +27,13 @@ env:
   PUBLISH: ${{ github.repository == 'mcruzdev/timeless' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect_changes.yml
+
   timeless-api:
     name: Build & Publish - Timeless API (Java)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -84,6 +95,8 @@ jobs:
 
   whatsapp:
     name: Build & Publish - WhatsApp Bot (Node.js)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.whatsapp == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/detect_changes.yml
+++ b/.github/workflows/detect_changes.yml
@@ -1,0 +1,32 @@
+name: Detect Changed Paths
+
+on:
+  workflow_call:
+    outputs:
+      api:
+        description: Whether API paths changed
+        value: ${{ jobs.changes.outputs.api }}
+      whatsapp:
+        description: Whether WhatsApp paths changed
+        value: ${{ jobs.changes.outputs.whatsapp }}
+
+jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      whatsapp: ${{ steps.filter.outputs.whatsapp }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'timeless-api/**'
+            whatsapp:
+              - 'whatsapp/**'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,9 @@ name: Timeless CI - Pull Request Build
 on:
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'timeless-api/**'
+      - 'whatsapp/**'
     paths-ignore:
       - 'infrastructure/**'
 
@@ -14,8 +17,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect_changes.yml
+
   timeless-api:
     name: Build Timeless API (Backend)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -56,6 +64,8 @@ jobs:
 
   whatsapp:
     name: Build WhatsApp Bot (Node.js)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.whatsapp == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'timeless-api/**'
       - 'whatsapp/**'
-    paths-ignore:
       - 'infrastructure/**'
 
 permissions:


### PR DESCRIPTION
A small suggestion from me:

Optimizes CI/CD workflows to execute only relevant jobs based on path changes.

Avoid unnecessary job execution when only the frontend or backend is modified, reducing CI/CD time and resource consumption.

Changes

Created `.github/workflows/detect_changes.yml` - reusable workflow that detects path changes
Refactored `build.yml` - now uses `detect_changes` and executes conditional jobs
Refactored `pull_request.yml` - now uses `detect_changes` and executes conditional jobs

### Build & Publish Workflow
- Job `timeless-api` executes only if `timeless-api/**` has been modified
- Job `whatsapp` executes only if `whatsapp/**` has been modified

Benefits
 Faster CI/CD - unnecessary jobs don't run
 Reduces resource consumption and CI/CD cost
 Faster feedback for developers
 Eliminates code duplication between workflows

